### PR TITLE
A fresh pull request which includes the patch to compile S2E on a Mac and the tips 

### DIFF
--- a/docs/BuildingS2E.html
+++ b/docs/BuildingS2E.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.8.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.10: http://docutils.sourceforge.net/" />
 <title>Building the S2E Platform</title>
 <link rel="stylesheet" href="./s2e.css" type="text/css" />
 </head>
@@ -11,16 +11,26 @@
 <div class="document" id="building-the-s2e-platform">
 <h1 class="title">Building the S2E Platform</h1>
 
-<p>The following steps describe the installation process in detail. We assume the installation
-is performed on an Ubuntu 12.04 64-bit host system (S2E also works on 64-bit Mac systems).</p>
+<p>The following steps describe the installation process in detail. We assume the
+installation is performed on an Ubuntu 12.04 64-bit host system (S2E also works
+on 64-bit Mac systems, and the build instructions can be found in the last
+chapter).</p>
 <div class="contents topic" id="contents">
 <p class="topic-title first">Contents</p>
 <ul class="simple">
-<li><a class="reference internal" href="#required-packages" id="id1">Required Packages</a></li>
-<li><a class="reference internal" href="#checking-out-s2e" id="id2">Checking out S2E</a></li>
-<li><a class="reference internal" href="#building-s2e" id="id3">Building S2E</a></li>
-<li><a class="reference internal" href="#updating-s2e" id="id4">Updating S2E</a></li>
-<li><a class="reference internal" href="#rebuilding-s2e-documentation" id="id5">Rebuilding S2E Documentation</a></li>
+<li><a class="reference internal" href="#required-packages" id="id3">Required Packages</a></li>
+<li><a class="reference internal" href="#checking-out-s2e" id="id4">Checking out S2E</a></li>
+<li><a class="reference internal" href="#building-s2e" id="id5">Building S2E</a></li>
+<li><a class="reference internal" href="#updating-s2e" id="id6">Updating S2E</a></li>
+<li><a class="reference internal" href="#rebuilding-s2e-documentation" id="id7">Rebuilding S2E Documentation</a></li>
+<li><a class="reference internal" href="#building-the-s2e-platform-on-a-mac" id="id8">Building the S2E Platform on a Mac</a><ul>
+<li><a class="reference internal" href="#installing-command-line-tools" id="id9">Installing Command Line Tools</a></li>
+<li><a class="reference internal" href="#installing-homebrew" id="id10">Installing Homebrew</a></li>
+<li><a class="reference internal" href="#installing-required-packages" id="id11">Installing required packages</a></li>
+<li><a class="reference internal" href="#creating-symlinks" id="id12">Creating symlinks</a></li>
+<li><a class="reference internal" href="#getting-and-building-the-s2e-source-code" id="id13">Getting and Building the S2E source code</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="required-packages">
@@ -38,8 +48,8 @@ $ sudo apt-get install python-docutils
 $ sudo apt-get install python-pygments
 $ sudo apt-get install nasm
 </pre>
-<p>The following commands ask <tt class="docutils literal"><span class="pre">apt-get</span></tt> to install build dependencies for llvm-3.0
-and qemu.</p>
+<p>The following commands ask <tt class="docutils literal"><span class="pre">apt-get</span></tt> to install build dependencies for
+llvm-3.0 and qemu.</p>
 <pre class="literal-block">
 $ sudo apt-get build-dep llvm-3.0
 $ sudo apt-get build-dep qemu
@@ -60,8 +70,8 @@ $ cd $S2EDIR
 $ git clone git&#64;github.com:dslab-epfl/s2e.git
 </pre>
 <p>In order to report bugs, please use GitHub's <a class="reference external" href="https://github.com/dslab-epfl/s2e/issues">issue tracker</a>. If you would like
-to contribute to S2E, please create your own personal clone of S2E on GitHub, push your changes to it and then send us a
-pull request.</p>
+to contribute to S2E, please create your own personal clone of S2E on GitHub,
+push your changes to it and then send us a pull request.</p>
 <p>You can find more information about using git on <a class="reference external" href="http://gitref.org/">http://gitref.org/</a> or on
 <a class="reference external" href="http://progit.org/">http://progit.org/</a>.</p>
 </div>
@@ -76,11 +86,13 @@ $ make -f ../s2e/Makefile
 &gt; Go make some coffee, this will take a lot of time
 </pre>
 <p>By default, the <tt class="docutils literal">make</tt> command compiles S2E in release mode. The resulting
-binary is placed in <tt class="docutils literal"><span class="pre">$S2EDIR/build/qemu-release/i386-s2e-softmmu/qemu-system-i386</span></tt>.
+binary is placed in
+<tt class="docutils literal"><span class="pre">$S2EDIR/build/qemu-release/i386-s2e-softmmu/qemu-system-i386</span></tt>.
 To compile in Debug mode, use <tt class="docutils literal">make <span class="pre">all-debug</span></tt>. The Makefile automatically
-uses the maximum number of available processors in order to speed up compilation.</p>
+uses the maximum number of available processors in order to speed up
+compilation.</p>
 <p>You can also build each component of S2E manually. Refer to the Makefile for
-the commands required to build all inidividual components.</p>
+the commands required to build all individual components.</p>
 </div>
 <div class="section" id="updating-s2e">
 <h1>Updating S2E</h1>
@@ -88,8 +100,8 @@ the commands required to build all inidividual components.</p>
 yourself or when pulling new versions through <tt class="docutils literal">git</tt>. Note that the Makefile
 will not automatically reconfigure the packages; for deep changes you might need
 to either start from scratch by issuing <tt class="docutils literal">make clean</tt> or to force
-the reconfiguration of specific modules by deleting  the corresponding files from
-the <tt class="docutils literal">stamps</tt> subdirectory.</p>
+the reconfiguration of specific modules by deleting  the corresponding files
+from the <tt class="docutils literal">stamps</tt> subdirectory.</p>
 </div>
 <div class="section" id="rebuilding-s2e-documentation">
 <h1>Rebuilding S2E Documentation</h1>
@@ -97,6 +109,98 @@ the <tt class="docutils literal">stamps</tt> subdirectory.</p>
 keep generated HTML files in the repository. Never change HTML files
 manually and always recompile them (by invoking <tt class="docutils literal">make</tt> in the docs folder)
 after changing any <tt class="docutils literal">RST</tt> files.</p>
+</div>
+<div class="section" id="building-the-s2e-platform-on-a-mac">
+<h1>Building the S2E Platform on a Mac</h1>
+<p>Basically, the building process on a Mac follows the same workflow as described
+above. However, since Mac has its own default environment and configurations for
+development, there are still some differences between.</p>
+<p>In the following steps, we assume the installation is performed on a clean Mac
+OS X Mountain Lion 10.8 host system.</p>
+<div class="section" id="installing-command-line-tools">
+<h2>Installing Command Line Tools</h2>
+<p>The &quot;Command Line Tools for Xcode&quot; provides a toolset for development via
+Terminal on a Mac OS X. There are two alternative ways to install it:</p>
+<ol class="arabic simple">
+<li>Go to the  <a class="reference external" href="https://developer.apple.com/downloads">Apple Developer Downloads</a> website with an Apple ID (the same
+as the one for iTunes and App purchases), search for the &quot;command line tools&quot;
+in the search field on the website, then click the last version of &quot;Command
+Line Tools (OS X Mountain Lion) for Xcode&quot;(~118MB), download and install it.</li>
+<li>Download Xcode from either <a class="reference external" href="https://developer.apple.com/downloads">Apple Developer Downloads</a> or the <a class="reference external" href="http://itunes.apple.com/us/app/xcode/id497799835?ls=1&amp;mt=12">Mac App Store</a>. Xcode is a
+massive beast (~2GB), make sure you have a high-bandwidth network connection.
+Once Xcode is installed, launch it, go to Xcode's &quot;Preference&quot; via the menu
+bar, then find the “Downloads” pane, and download the &quot;Command Line Tools&quot;
+from within the application.</li>
+</ol>
+</div>
+<div class="section" id="installing-homebrew">
+<h2>Installing Homebrew</h2>
+<p>There are several package managers on OS X, such as <a class="reference external" href="http://mxcl.github.io/homebrew/">Homebrew</a> and <a class="reference external" href="http://www.macports.org/index.php">MacPorts</a>. In this tutorial, we use Homebrew. To
+install <a class="reference external" href="http://mxcl.github.io/homebrew/">Homebrew</a>, simply run the following
+command in your Terminal:</p>
+<pre class="literal-block">
+$ ruby -e &quot;$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)&quot;
+</pre>
+<p>It will prompt you what to do before the installation begins. Once installed,
+insert the Homebrew directory at the top of your <tt class="docutils literal">PATH</tt> environment variable. You
+can do this by adding the following line at the bottom of your <tt class="docutils literal"><span class="pre">~/.profile</span></tt>
+file:</p>
+<pre class="literal-block">
+PATH=/usr/local/bin:$PATH
+export PATH
+</pre>
+<p>Then, run <tt class="docutils literal">brew doctor</tt> to ensure there are not any potential problems with
+your environment. If you get</p>
+<pre class="literal-block">
+Your system is ready to brew
+</pre>
+<p>you can move on to the next step, otherwise, refer to the Homebrew's
+<a class="reference external" href="https://github.com/mxcl/homebrew/wiki/Troubleshooting">Troubleshooting</a> to
+fix errors and warnings you might run into.</p>
+</div>
+<div class="section" id="installing-required-packages">
+<h2>Installing required packages</h2>
+<p>After the package manager is ready, type the following commands to install the
+required packages:</p>
+<pre class="literal-block">
+$ brew install git wget binutils gettext pkgconfig glib lua libsigc++ nasm
+</pre>
+<p>If you want to compile the S2E documentation, you also need <tt class="docutils literal">docutils</tt> and
+<tt class="docutils literal">pygments</tt> tools, which are both Python packages. Since an out-of-box version
+of Python 2.7 is distributed by Mac OS X, we can directly install the two
+packages once Python's own package manager <tt class="docutils literal">pip</tt> is installed</p>
+<pre class="literal-block">
+$ sudo easy_install pip
+$ sudo pip install docutils pygments
+</pre>
+</div>
+<div class="section" id="creating-symlinks">
+<h2>Creating symlinks</h2>
+<p>Unlike the <tt class="docutils literal"><span class="pre">apt-get</span></tt> of Ubuntu, some libraries installed by Homebrew are not
+placed in the directories that S2E can find. The simplest solution is to create
+symlinks to these libraries in the <tt class="docutils literal">/opt/local/lib/x86_64/</tt> directory
+respectively.  Maybe you need the following command to create the directory
+first:</p>
+<pre class="literal-block">
+$ mkdir -p /opt/local/lib/x86_64
+</pre>
+<p>The symlinks can be created as follows:</p>
+<pre class="literal-block">
+$ sudo ln -s $PATH_TO_ORIGINAL_LIBS $SYMLINK_WITH_SAME_NAME
+</pre>
+<p>The <tt class="docutils literal">$PATH_TO_ORIGINAL_LIBS</tt> variable includes:</p>
+<pre class="literal-block">
+/usr/local/Cellar/gettext/0.18.2/lib/libintl.*
+/usr/local/Cellar/gettext/0.18.2/lib/libgettextpo.*
+/usr/local/lib/x86_64/libiberty.a
+</pre>
+<p>&quot;*&quot; stands for <tt class="docutils literal">a</tt> and <tt class="docutils literal">dylib</tt>.</p>
+</div>
+<div class="section" id="getting-and-building-the-s2e-source-code">
+<h2>Getting and Building the S2E source code</h2>
+<p>Just follow the instructions in the <a class="reference internal" href="#checking-out-s2e">Checking out S2E</a> and <a class="reference internal" href="#building-s2e">Building S2E</a>
+sections above.</p>
+</div>
 </div>
 </div>
 <div class="footer">

--- a/docs/BuildingS2E.rst
+++ b/docs/BuildingS2E.rst
@@ -2,8 +2,10 @@
 Building the S2E Platform
 ==========================
 
-The following steps describe the installation process in detail. We assume the installation
-is performed on an Ubuntu 12.04 64-bit host system (S2E also works on 64-bit Mac systems).
+The following steps describe the installation process in detail. We assume the 
+installation is performed on an Ubuntu 12.04 64-bit host system (S2E also works 
+on 64-bit Mac systems, and the build instructions can be found in the last 
+chapter).
 
 .. contents::
 
@@ -24,8 +26,8 @@ Required Packages
     $ sudo apt-get install python-pygments
     $ sudo apt-get install nasm
 
-The following commands ask ``apt-get`` to install build dependencies for llvm-3.0
-and qemu. ::
+The following commands ask ``apt-get`` to install build dependencies for 
+llvm-3.0 and qemu. ::
 
     $ sudo apt-get build-dep llvm-3.0
     $ sudo apt-get build-dep qemu
@@ -46,11 +48,13 @@ You can also clone S2E via SSH::
    $ cd $S2EDIR
    $ git clone git@github.com:dslab-epfl/s2e.git
 
-In order to report bugs, please use GitHub's `issue tracker <https://github.com/dslab-epfl/s2e/issues>`_. If you would like
-to contribute to S2E, please create your own personal clone of S2E on GitHub, push your changes to it and then send us a
-pull request.
+In order to report bugs, please use GitHub's `issue tracker 
+<https://github.com/dslab-epfl/s2e/issues>`_. If you would like
+to contribute to S2E, please create your own personal clone of S2E on GitHub, 
+push your changes to it and then send us a pull request.
 
-You can find more information about using git on `http://gitref.org/ <http://gitref.org/>`_ or on
+You can find more information about using git on `http://gitref.org/ 
+<http://gitref.org/>`_ or on
 `http://progit.org/ <http://progit.org/>`_.
 
 
@@ -66,12 +70,14 @@ The recommended method of building S2E is using the S2E Makefile::
    > Go make some coffee, this will take a lot of time
 
 By default, the ``make`` command compiles S2E in release mode. The resulting
-binary is placed in ``$S2EDIR/build/qemu-release/i386-s2e-softmmu/qemu-system-i386``.
+binary is placed in 
+``$S2EDIR/build/qemu-release/i386-s2e-softmmu/qemu-system-i386``.
 To compile in Debug mode, use ``make all-debug``. The Makefile automatically
-uses the maximum number of available processors in order to speed up compilation.
+uses the maximum number of available processors in order to speed up 
+compilation.
 
 You can also build each component of S2E manually. Refer to the Makefile for
-the commands required to build all inidividual components.
+the commands required to build all individual components.
 
 Updating S2E
 ============
@@ -80,8 +86,8 @@ You can use the same Makefile to recompile S2E either when changing it
 yourself or when pulling new versions through ``git``. Note that the Makefile
 will not automatically reconfigure the packages; for deep changes you might need
 to either start from scratch by issuing ``make clean`` or to force
-the reconfiguration of specific modules by deleting  the corresponding files from
-the ``stamps`` subdirectory.
+the reconfiguration of specific modules by deleting  the corresponding files 
+from the ``stamps`` subdirectory.
 
 Rebuilding S2E Documentation
 =============================
@@ -92,3 +98,106 @@ keep generated HTML files in the repository. Never change HTML files
 manually and always recompile them (by invoking ``make`` in the docs folder)
 after changing any ``RST`` files.
 
+
+Building the S2E Platform on a Mac 
+===================================
+
+Basically, the building process on a Mac follows the same workflow as described 
+above. However, since Mac has its own default environment and configurations for 
+development, there are still some differences between. 
+
+In the following steps, we assume the installation is performed on a clean Mac 
+OS X Mountain Lion 10.8 host system.
+
+Installing Command Line Tools
+-----------------------------
+
+The "Command Line Tools for Xcode" provides a toolset for development via 
+Terminal on a Mac OS X. There are two alternative ways to install it:
+
+1. Go to the  `Apple Developer Downloads 
+   <https://developer.apple.com/downloads>`_ website with an Apple ID (the same 
+   as the one for iTunes and App purchases), search for the "command line tools" 
+   in the search field on the website, then click the last version of "Command 
+   Line Tools (OS X Mountain Lion) for Xcode"(~118MB), download and install it.
+
+2. Download Xcode from either `Apple Developer Downloads 
+   <https://developer.apple.com/downloads>`_ or the `Mac App Store 
+   <http://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12>`_. Xcode is a 
+   massive beast (~2GB), make sure you have a high-bandwidth network connection.  
+   Once Xcode is installed, launch it, go to Xcode's "Preference" via the menu 
+   bar, then find the “Downloads” pane, and download the "Command Line Tools" 
+   from within the application.
+
+Installing Homebrew
+--------------------
+
+There are several package managers on OS X, such as `Homebrew 
+<http://mxcl.github.io/homebrew/>`_ and `MacPorts 
+<http://www.macports.org/index.php>`_. In this tutorial, we use Homebrew. To 
+install `Homebrew <http://mxcl.github.io/homebrew/>`_, simply run the following 
+command in your Terminal:: 
+
+    $ ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)" 
+
+It will prompt you what to do before the installation begins. Once installed, 
+insert the Homebrew directory at the top of your ``PATH`` environment variable. You 
+can do this by adding the following line at the bottom of your ``~/.profile`` 
+file::
+
+    PATH=/usr/local/bin:$PATH
+    export PATH
+    
+Then, run ``brew doctor`` to ensure there are not any potential problems with 
+your environment. If you get ::
+    
+    Your system is ready to brew
+
+you can move on to the next step, otherwise, refer to the Homebrew's 
+`Troubleshooting <https://github.com/mxcl/homebrew/wiki/Troubleshooting>`_ to 
+fix errors and warnings you might run into.
+
+Installing required packages
+----------------------------
+
+After the package manager is ready, type the following commands to install the 
+required packages:: 
+
+    $ brew install git wget binutils gettext pkgconfig glib lua libsigc++ nasm
+
+If you want to compile the S2E documentation, you also need ``docutils`` and 
+``pygments`` tools, which are both Python packages. Since an out-of-box version 
+of Python 2.7 is distributed by Mac OS X, we can directly install the two 
+packages once Python's own package manager ``pip`` is installed ::
+
+    $ sudo easy_install pip
+    $ sudo pip install docutils pygments
+
+Creating symlinks
+-----------------
+
+Unlike the ``apt-get`` of Ubuntu, some libraries installed by Homebrew are not 
+placed in the directories that S2E can find. The simplest solution is to create 
+symlinks to these libraries in the ``/opt/local/lib/x86_64/`` directory 
+respectively.  Maybe you need the following command to create the directory 
+first::
+
+    $ mkdir -p /opt/local/lib/x86_64
+
+The symlinks can be created as follows::
+
+    $ sudo ln -s $PATH_TO_ORIGINAL_LIBS $SYMLINK_WITH_SAME_NAME
+
+The ``$PATH_TO_ORIGINAL_LIBS`` variable includes::
+
+    /usr/local/Cellar/gettext/0.18.2/lib/libintl.* 
+    /usr/local/Cellar/gettext/0.18.2/lib/libgettextpo.* 
+    /usr/local/lib/x86_64/libiberty.a
+
+"*" stands for ``a`` and ``dylib``. 
+
+Getting and Building the S2E source code  
+----------------------------------------
+
+Just follow the instructions in the `Checking out S2E`_ and `Building S2E`_ 
+sections above.

--- a/qemu/configure
+++ b/qemu/configure
@@ -484,8 +484,10 @@ Darwin)
   cocoa="yes"
   audio_drv_list="coreaudio"
   audio_possible_drivers="coreaudio sdl fmod"
-  LDFLAGS="-framework CoreFoundation -framework IOKit $LDFLAGS"
-  libs_softmmu="-F/System/Library/Frameworks -framework Cocoa -framework IOKit $libs_softmmu"
+  QEMU_CXXFLAGS="-fvisibility-inlines-hidden $QEMU_CXXFLAGS"
+  LDFLAGS="-framework CoreFoundation -framework IOKit -Wl,-undefined,dynamic_lookup $LDFLAGS" 
+  libs_softmmu="-F/System/Library/Frameworks -framework Cocoa -framework IOKit 
+  $libs_softmmu"
 ;;
 SunOS)
   solaris="yes"

--- a/qemu/fpu/softfloat-macros.h
+++ b/qemu/fpu/softfloat-macros.h
@@ -55,7 +55,7 @@ these four paragraphs for those parts of this code that are retained.
 | The result is stored in the location pointed to by `zPtr'.
 *----------------------------------------------------------------------------*/
 
-INLINE void shift32RightJamming( uint32_t a, int16 count, uint32_t *zPtr )
+INLINE void shift32RightJamming(uint32_t a, int_fast16_t count, uint32_t *zPtr)
 {
     uint32_t z;
 
@@ -81,7 +81,7 @@ INLINE void shift32RightJamming( uint32_t a, int16 count, uint32_t *zPtr )
 | The result is stored in the location pointed to by `zPtr'.
 *----------------------------------------------------------------------------*/
 
-INLINE void shift64RightJamming( uint64_t a, int16 count, uint64_t *zPtr )
+INLINE void shift64RightJamming(uint64_t a, int_fast16_t count, uint64_t *zPtr)
 {
     uint64_t z;
 
@@ -117,7 +117,7 @@ INLINE void shift64RightJamming( uint64_t a, int16 count, uint64_t *zPtr )
 
 INLINE void
  shift64ExtraRightJamming(
-     uint64_t a0, uint64_t a1, int16 count, uint64_t *z0Ptr, uint64_t *z1Ptr )
+     uint64_t a0, uint64_t a1, int_fast16_t count, uint64_t *z0Ptr, uint64_t *z1Ptr)
 {
     uint64_t z0, z1;
     int8 negCount = ( - count ) & 63;
@@ -154,7 +154,7 @@ INLINE void
 
 INLINE void
  shift128Right(
-     uint64_t a0, uint64_t a1, int16 count, uint64_t *z0Ptr, uint64_t *z1Ptr )
+     uint64_t a0, uint64_t a1, int_fast16_t count, uint64_t *z0Ptr, uint64_t *z1Ptr)
 {
     uint64_t z0, z1;
     int8 negCount = ( - count ) & 63;
@@ -168,7 +168,7 @@ INLINE void
         z0 = a0>>count;
     }
     else {
-        z1 = ( count < 64 ) ? ( a0>>( count & 63 ) ) : 0;
+        z1 = (count < 128) ? (a0 >> (count & 63)) : 0;
         z0 = 0;
     }
     *z1Ptr = z1;
@@ -189,7 +189,7 @@ INLINE void
 
 INLINE void
  shift128RightJamming(
-     uint64_t a0, uint64_t a1, int16 count, uint64_t *z0Ptr, uint64_t *z1Ptr )
+     uint64_t a0, uint64_t a1, int_fast16_t count, uint64_t *z0Ptr, uint64_t *z1Ptr)
 {
     uint64_t z0, z1;
     int8 negCount = ( - count ) & 63;
@@ -243,7 +243,7 @@ INLINE void
      uint64_t a0,
      uint64_t a1,
      uint64_t a2,
-     int16 count,
+     int_fast16_t count,
      uint64_t *z0Ptr,
      uint64_t *z1Ptr,
      uint64_t *z2Ptr
@@ -298,7 +298,7 @@ INLINE void
 
 INLINE void
  shortShift128Left(
-     uint64_t a0, uint64_t a1, int16 count, uint64_t *z0Ptr, uint64_t *z1Ptr )
+     uint64_t a0, uint64_t a1, int_fast16_t count, uint64_t *z0Ptr, uint64_t *z1Ptr)
 {
 
     *z1Ptr = a1<<count;
@@ -320,7 +320,7 @@ INLINE void
      uint64_t a0,
      uint64_t a1,
      uint64_t a2,
-     int16 count,
+     int_fast16_t count,
      uint64_t *z0Ptr,
      uint64_t *z1Ptr,
      uint64_t *z2Ptr
@@ -591,7 +591,7 @@ static uint64_t estimateDiv128To64( uint64_t a0, uint64_t a1, uint64_t b )
 | value.
 *----------------------------------------------------------------------------*/
 
-static uint32_t estimateSqrt32( int16 aExp, uint32_t a )
+static uint32_t estimateSqrt32(int_fast16_t aExp, uint32_t a)
 {
     static const uint16_t sqrtOddAdjustments[] = {
         0x0004, 0x0022, 0x005D, 0x00B1, 0x011D, 0x019F, 0x0236, 0x02E0,

--- a/qemu/fpu/softfloat.c
+++ b/qemu/fpu/softfloat.c
@@ -40,7 +40,7 @@ these four paragraphs for those parts of this code that are retained.
  */
 #include "config.h"
 
-#include "softfloat.h"
+#include "fpu/softfloat.h"
 
 /*----------------------------------------------------------------------------
 | Primitive arithmetic functions, including multi-word arithmetic, and
@@ -87,7 +87,7 @@ INLINE uint32_t extractFloat16Frac(float16 a)
 | Returns the exponent bits of the half-precision floating-point value `a'.
 *----------------------------------------------------------------------------*/
 
-INLINE int16 extractFloat16Exp(float16 a)
+INLINE int_fast16_t extractFloat16Exp(float16 a)
 {
     return (float16_val(a) >> 10) & 0x1f;
 }
@@ -218,7 +218,7 @@ INLINE uint32_t extractFloat32Frac( float32 a )
 | Returns the exponent bits of the single-precision floating-point value `a'.
 *----------------------------------------------------------------------------*/
 
-INLINE int16 extractFloat32Exp( float32 a )
+INLINE int_fast16_t extractFloat32Exp(float32 a)
 {
 
     return ( float32_val(a)>>23 ) & 0xFF;
@@ -259,7 +259,7 @@ static float32 float32_squash_input_denormal(float32 a STATUS_PARAM)
 *----------------------------------------------------------------------------*/
 
 static void
- normalizeFloat32Subnormal( uint32_t aSig, int16 *zExpPtr, uint32_t *zSigPtr )
+ normalizeFloat32Subnormal(uint32_t aSig, int_fast16_t *zExpPtr, uint32_t *zSigPtr)
 {
     int8 shiftCount;
 
@@ -280,7 +280,7 @@ static void
 | significand.
 *----------------------------------------------------------------------------*/
 
-INLINE float32 packFloat32( flag zSign, int16 zExp, uint32_t zSig )
+INLINE float32 packFloat32(flag zSign, int_fast16_t zExp, uint32_t zSig)
 {
 
     return make_float32(
@@ -310,7 +310,7 @@ INLINE float32 packFloat32( flag zSign, int16 zExp, uint32_t zSig )
 | Binary Floating-Point Arithmetic.
 *----------------------------------------------------------------------------*/
 
-static float32 roundAndPackFloat32( flag zSign, int16 zExp, uint32_t zSig STATUS_PARAM)
+static float32 roundAndPackFloat32(flag zSign, int_fast16_t zExp, uint32_t zSig STATUS_PARAM)
 {
     int8 roundingMode;
     flag roundNearestEven;
@@ -376,7 +376,7 @@ static float32 roundAndPackFloat32( flag zSign, int16 zExp, uint32_t zSig STATUS
 *----------------------------------------------------------------------------*/
 
 static float32
- normalizeRoundAndPackFloat32( flag zSign, int16 zExp, uint32_t zSig STATUS_PARAM)
+ normalizeRoundAndPackFloat32(flag zSign, int_fast16_t zExp, uint32_t zSig STATUS_PARAM)
 {
     int8 shiftCount;
 
@@ -400,7 +400,7 @@ INLINE uint64_t extractFloat64Frac( float64 a )
 | Returns the exponent bits of the double-precision floating-point value `a'.
 *----------------------------------------------------------------------------*/
 
-INLINE int16 extractFloat64Exp( float64 a )
+INLINE int_fast16_t extractFloat64Exp(float64 a)
 {
 
     return ( float64_val(a)>>52 ) & 0x7FF;
@@ -441,7 +441,7 @@ static float64 float64_squash_input_denormal(float64 a STATUS_PARAM)
 *----------------------------------------------------------------------------*/
 
 static void
- normalizeFloat64Subnormal( uint64_t aSig, int16 *zExpPtr, uint64_t *zSigPtr )
+ normalizeFloat64Subnormal(uint64_t aSig, int_fast16_t *zExpPtr, uint64_t *zSigPtr)
 {
     int8 shiftCount;
 
@@ -462,7 +462,7 @@ static void
 | significand.
 *----------------------------------------------------------------------------*/
 
-INLINE float64 packFloat64( flag zSign, int16 zExp, uint64_t zSig )
+INLINE float64 packFloat64(flag zSign, int_fast16_t zExp, uint64_t zSig)
 {
 
     return make_float64(
@@ -492,11 +492,11 @@ INLINE float64 packFloat64( flag zSign, int16 zExp, uint64_t zSig )
 | Binary Floating-Point Arithmetic.
 *----------------------------------------------------------------------------*/
 
-static float64 roundAndPackFloat64( flag zSign, int16 zExp, uint64_t zSig STATUS_PARAM)
+static float64 roundAndPackFloat64(flag zSign, int_fast16_t zExp, uint64_t zSig STATUS_PARAM)
 {
     int8 roundingMode;
     flag roundNearestEven;
-    int16 roundIncrement, roundBits;
+    int_fast16_t roundIncrement, roundBits;
     flag isTiny;
 
     roundingMode = STATUS(float_rounding_mode);
@@ -558,7 +558,7 @@ static float64 roundAndPackFloat64( flag zSign, int16 zExp, uint64_t zSig STATUS
 *----------------------------------------------------------------------------*/
 
 static float64
- normalizeRoundAndPackFloat64( flag zSign, int16 zExp, uint64_t zSig STATUS_PARAM)
+ normalizeRoundAndPackFloat64(flag zSign, int_fast16_t zExp, uint64_t zSig STATUS_PARAM)
 {
     int8 shiftCount;
 
@@ -1238,7 +1238,7 @@ float32 uint64_to_float32( uint64 a STATUS_PARAM )
     if ( a == 0 ) return float32_zero;
     shiftCount = countLeadingZeros64( a ) - 40;
     if ( 0 <= shiftCount ) {
-        return packFloat32( 1 > 0, 0x95 - shiftCount, a<<shiftCount );
+        return packFloat32(0, 0x95 - shiftCount, a<<shiftCount);
     }
     else {
         shiftCount += 7;
@@ -1248,7 +1248,7 @@ float32 uint64_to_float32( uint64 a STATUS_PARAM )
         else {
             a <<= shiftCount;
         }
-        return roundAndPackFloat32( 1 > 0, 0x9C - shiftCount, a STATUS_VAR );
+        return roundAndPackFloat32(0, 0x9C - shiftCount, a STATUS_VAR);
     }
 }
 
@@ -1271,11 +1271,18 @@ float64 int64_to_float64( int64 a STATUS_PARAM )
 
 }
 
-float64 uint64_to_float64( uint64 a STATUS_PARAM )
+float64 uint64_to_float64(uint64 a STATUS_PARAM)
 {
-    if ( a == 0 ) return float64_zero;
-    return normalizeRoundAndPackFloat64( 0, 0x43C, a STATUS_VAR );
+    int exp =  0x43C;
 
+    if (a == 0) {
+        return float64_zero;
+    }
+    if ((int64_t)a < 0) {
+        shift64RightJamming(a, 1, &a);
+        exp += 1;
+    }
+    return normalizeRoundAndPackFloat64(0, exp, a STATUS_VAR);
 }
 
 /*----------------------------------------------------------------------------
@@ -1332,6 +1339,14 @@ float128 int64_to_float128( int64 a STATUS_PARAM )
 
 }
 
+float128 uint64_to_float128(uint64 a STATUS_PARAM)
+{
+    if (a == 0) {
+        return float128_zero;
+    }
+    return normalizeRoundAndPackFloat128(0, 0x406E, a, 0 STATUS_VAR);
+}
+
 /*----------------------------------------------------------------------------
 | Returns the result of converting the single-precision floating-point value
 | `a' to the 32-bit two's complement integer format.  The conversion is
@@ -1345,7 +1360,7 @@ float128 int64_to_float128( int64 a STATUS_PARAM )
 int32 float32_to_int32( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint32_t aSig;
     uint64_t aSig64;
 
@@ -1376,7 +1391,7 @@ int32 float32_to_int32( float32 a STATUS_PARAM )
 int32 float32_to_int32_round_to_zero( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint32_t aSig;
     int32_t z;
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -1416,10 +1431,10 @@ int32 float32_to_int32_round_to_zero( float32 a STATUS_PARAM )
 | returned.
 *----------------------------------------------------------------------------*/
 
-int16 float32_to_int16_round_to_zero( float32 a STATUS_PARAM )
+int_fast16_t float32_to_int16_round_to_zero(float32 a STATUS_PARAM)
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint32_t aSig;
     int32 z;
 
@@ -1468,7 +1483,7 @@ int16 float32_to_int16_round_to_zero( float32 a STATUS_PARAM )
 int64 float32_to_int64( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint32_t aSig;
     uint64_t aSig64, aSigExtra;
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -1505,7 +1520,7 @@ int64 float32_to_int64( float32 a STATUS_PARAM )
 int64 float32_to_int64_round_to_zero( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint32_t aSig;
     uint64_t aSig64;
     int64 z;
@@ -1549,7 +1564,7 @@ int64 float32_to_int64_round_to_zero( float32 a STATUS_PARAM )
 float64 float32_to_float64( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
     a = float32_squash_input_denormal(a STATUS_VAR);
 
@@ -1579,7 +1594,7 @@ float64 float32_to_float64( float32 a STATUS_PARAM )
 floatx80 float32_to_floatx80( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
 
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -1609,7 +1624,7 @@ floatx80 float32_to_floatx80( float32 a STATUS_PARAM )
 float128 float32_to_float128( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
 
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -1639,7 +1654,7 @@ float128 float32_to_float128( float32 a STATUS_PARAM )
 float32 float32_round_to_int( float32 a STATUS_PARAM)
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t lastBitMask, roundBitsMask;
     int8 roundingMode;
     uint32_t z;
@@ -1699,9 +1714,9 @@ float32 float32_round_to_int( float32 a STATUS_PARAM)
 
 static float32 addFloat32Sigs( float32 a, float32 b, flag zSign STATUS_PARAM)
 {
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint32_t aSig, bSig, zSig;
-    int16 expDiff;
+    int_fast16_t expDiff;
 
     aSig = extractFloat32Frac( a );
     aExp = extractFloat32Exp( a );
@@ -1778,9 +1793,9 @@ static float32 addFloat32Sigs( float32 a, float32 b, flag zSign STATUS_PARAM)
 
 static float32 subFloat32Sigs( float32 a, float32 b, flag zSign STATUS_PARAM)
 {
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint32_t aSig, bSig, zSig;
-    int16 expDiff;
+    int_fast16_t expDiff;
 
     aSig = extractFloat32Frac( a );
     aExp = extractFloat32Exp( a );
@@ -1898,7 +1913,7 @@ float32 float32_sub( float32 a, float32 b STATUS_PARAM )
 float32 float32_mul( float32 a, float32 b STATUS_PARAM )
 {
     flag aSign, bSign, zSign;
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint32_t aSig, bSig;
     uint64_t zSig64;
     uint32_t zSig;
@@ -1961,7 +1976,7 @@ float32 float32_mul( float32 a, float32 b STATUS_PARAM )
 float32 float32_div( float32 a, float32 b STATUS_PARAM )
 {
     flag aSign, bSign, zSign;
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint32_t aSig, bSig, zSig;
     a = float32_squash_input_denormal(a STATUS_VAR);
     b = float32_squash_input_denormal(b STATUS_VAR);
@@ -2025,7 +2040,7 @@ float32 float32_div( float32 a, float32 b STATUS_PARAM )
 float32 float32_rem( float32 a, float32 b STATUS_PARAM )
 {
     flag aSign, zSign;
-    int16 aExp, bExp, expDiff;
+    int_fast16_t aExp, bExp, expDiff;
     uint32_t aSig, bSig;
     uint32_t q;
     uint64_t aSig64, bSig64, q64;
@@ -2131,7 +2146,7 @@ float32 float32_rem( float32 a, float32 b STATUS_PARAM )
 float32 float32_muladd(float32 a, float32 b, float32 c, int flags STATUS_PARAM)
 {
     flag aSign, bSign, cSign, zSign;
-    int aExp, bExp, cExp, pExp, zExp, expDiff;
+    int_fast16_t aExp, bExp, cExp, pExp, zExp, expDiff;
     uint32_t aSig, bSig, cSig;
     flag pInf, pZero, pSign;
     uint64_t pSig64, cSig64, zSig64;
@@ -2219,7 +2234,7 @@ float32 float32_muladd(float32 a, float32 b, float32 c, int flags STATUS_PARAM)
             }
         }
         /* Zero plus something non-zero : just return the something */
-        return c ^ (signflip << 31);
+        return packFloat32(cSign ^ signflip, cExp, cSig);
     }
 
     if (aExp == 0) {
@@ -2333,7 +2348,7 @@ float32 float32_muladd(float32 a, float32 b, float32 c, int flags STATUS_PARAM)
 float32 float32_sqrt( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, zExp;
+    int_fast16_t aExp, zExp;
     uint32_t aSig, zSig;
     uint64_t rem, term;
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -2419,7 +2434,7 @@ static const float64 float32_exp2_coefficients[15] =
 float32 float32_exp2( float32 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
     float64 r, x, xn;
     int i;
@@ -2467,7 +2482,7 @@ float32 float32_exp2( float32 a STATUS_PARAM )
 float32 float32_log2( float32 a STATUS_PARAM )
 {
     flag aSign, zSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig, zSig, i;
 
     a = float32_squash_input_denormal(a STATUS_VAR);
@@ -2732,7 +2747,7 @@ int float32_unordered_quiet( float32 a, float32 b STATUS_PARAM )
 int32 float64_to_int32( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint64_t aSig;
     a = float64_squash_input_denormal(a STATUS_VAR);
 
@@ -2760,7 +2775,7 @@ int32 float64_to_int32( float64 a STATUS_PARAM )
 int32 float64_to_int32_round_to_zero( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint64_t aSig, savedASig;
     int32_t z;
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -2804,10 +2819,10 @@ int32 float64_to_int32_round_to_zero( float64 a STATUS_PARAM )
 | returned.
 *----------------------------------------------------------------------------*/
 
-int16 float64_to_int16_round_to_zero( float64 a STATUS_PARAM )
+int_fast16_t float64_to_int16_round_to_zero(float64 a STATUS_PARAM)
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint64_t aSig, savedASig;
     int32 z;
 
@@ -2858,7 +2873,7 @@ int16 float64_to_int16_round_to_zero( float64 a STATUS_PARAM )
 int64 float64_to_int64( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint64_t aSig, aSigExtra;
     a = float64_squash_input_denormal(a STATUS_VAR);
 
@@ -2901,7 +2916,7 @@ int64 float64_to_int64( float64 a STATUS_PARAM )
 int64 float64_to_int64_round_to_zero( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, shiftCount;
+    int_fast16_t aExp, shiftCount;
     uint64_t aSig;
     int64 z;
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -2951,7 +2966,7 @@ int64 float64_to_int64_round_to_zero( float64 a STATUS_PARAM )
 float32 float64_to_float32( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t aSig;
     uint32_t zSig;
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -2984,7 +2999,7 @@ float32 float64_to_float32( float64 a STATUS_PARAM )
 | than the desired result exponent whenever `zSig' is a complete, normalized
 | significand.
 *----------------------------------------------------------------------------*/
-static float16 packFloat16(flag zSign, int16 zExp, uint16_t zSig)
+static float16 packFloat16(flag zSign, int_fast16_t zExp, uint16_t zSig)
 {
     return make_float16(
         (((uint32_t)zSign) << 15) + (((uint32_t)zExp) << 10) + zSig);
@@ -2996,7 +3011,7 @@ static float16 packFloat16(flag zSign, int16 zExp, uint16_t zSig)
 float32 float16_to_float32(float16 a, flag ieee STATUS_PARAM)
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
 
     aSign = extractFloat16Sign(a);
@@ -3007,7 +3022,7 @@ float32 float16_to_float32(float16 a, flag ieee STATUS_PARAM)
         if (aSig) {
             return commonNaNToFloat32(float16ToCommonNaN(a STATUS_VAR) STATUS_VAR);
         }
-        return packFloat32(aSign, 0xff, aSig << 13);
+        return packFloat32(aSign, 0xff, 0);
     }
     if (aExp == 0) {
         int8 shiftCount;
@@ -3026,7 +3041,7 @@ float32 float16_to_float32(float16 a, flag ieee STATUS_PARAM)
 float16 float32_to_float16(float32 a, flag ieee STATUS_PARAM)
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint32_t aSig;
     uint32_t mask;
     uint32_t increment;
@@ -3127,7 +3142,7 @@ float16 float32_to_float16(float32 a, flag ieee STATUS_PARAM)
 floatx80 float64_to_floatx80( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t aSig;
 
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -3158,7 +3173,7 @@ floatx80 float64_to_floatx80( float64 a STATUS_PARAM )
 float128 float64_to_float128( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t aSig, zSig0, zSig1;
 
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -3189,7 +3204,7 @@ float128 float64_to_float128( float64 a STATUS_PARAM )
 float64 float64_round_to_int( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t lastBitMask, roundBitsMask;
     int8 roundingMode;
     uint64_t z;
@@ -3262,9 +3277,9 @@ float64 float64_trunc_to_int( float64 a STATUS_PARAM)
 
 static float64 addFloat64Sigs( float64 a, float64 b, flag zSign STATUS_PARAM )
 {
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint64_t aSig, bSig, zSig;
-    int16 expDiff;
+    int_fast16_t expDiff;
 
     aSig = extractFloat64Frac( a );
     aExp = extractFloat64Exp( a );
@@ -3341,9 +3356,9 @@ static float64 addFloat64Sigs( float64 a, float64 b, flag zSign STATUS_PARAM )
 
 static float64 subFloat64Sigs( float64 a, float64 b, flag zSign STATUS_PARAM )
 {
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint64_t aSig, bSig, zSig;
-    int16 expDiff;
+    int_fast16_t expDiff;
 
     aSig = extractFloat64Frac( a );
     aExp = extractFloat64Exp( a );
@@ -3461,7 +3476,7 @@ float64 float64_sub( float64 a, float64 b STATUS_PARAM )
 float64 float64_mul( float64 a, float64 b STATUS_PARAM )
 {
     flag aSign, bSign, zSign;
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint64_t aSig, bSig, zSig0, zSig1;
 
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -3522,7 +3537,7 @@ float64 float64_mul( float64 a, float64 b STATUS_PARAM )
 float64 float64_div( float64 a, float64 b STATUS_PARAM )
 {
     flag aSign, bSign, zSign;
-    int16 aExp, bExp, zExp;
+    int_fast16_t aExp, bExp, zExp;
     uint64_t aSig, bSig, zSig;
     uint64_t rem0, rem1;
     uint64_t term0, term1;
@@ -3594,7 +3609,7 @@ float64 float64_div( float64 a, float64 b STATUS_PARAM )
 float64 float64_rem( float64 a, float64 b STATUS_PARAM )
 {
     flag aSign, zSign;
-    int16 aExp, bExp, expDiff;
+    int_fast16_t aExp, bExp, expDiff;
     uint64_t aSig, bSig;
     uint64_t q, alternateASig;
     int64_t sigMean;
@@ -3685,7 +3700,7 @@ float64 float64_rem( float64 a, float64 b STATUS_PARAM )
 float64 float64_muladd(float64 a, float64 b, float64 c, int flags STATUS_PARAM)
 {
     flag aSign, bSign, cSign, zSign;
-    int aExp, bExp, cExp, pExp, zExp, expDiff;
+    int_fast16_t aExp, bExp, cExp, pExp, zExp, expDiff;
     uint64_t aSig, bSig, cSig;
     flag pInf, pZero, pSign;
     uint64_t pSig0, pSig1, cSig0, cSig1, zSig0, zSig1;
@@ -3772,7 +3787,7 @@ float64 float64_muladd(float64 a, float64 b, float64 c, int flags STATUS_PARAM)
             }
         }
         /* Zero plus something non-zero : just return the something */
-        return c ^ ((uint64_t)signflip << 63);
+        return packFloat64(cSign ^ signflip, cExp, cSig);
     }
 
     if (aExp == 0) {
@@ -3883,9 +3898,15 @@ float64 float64_muladd(float64 a, float64 b, float64 c, int flags STATUS_PARAM)
             }
             zExp -= shiftcount;
         } else {
-            shiftcount = countLeadingZeros64(zSig1) - 1;
-            zSig0 = zSig1 << shiftcount;
-            zExp -= (shiftcount + 64);
+            shiftcount = countLeadingZeros64(zSig1);
+            if (shiftcount == 0) {
+                zSig0 = (zSig1 >> 1) | (zSig1 & 1);
+                zExp -= 63;
+            } else {
+                shiftcount--;
+                zSig0 = zSig1 << shiftcount;
+                zExp -= (shiftcount + 64);
+            }
         }
         return roundAndPackFloat64(zSign, zExp, zSig0 STATUS_VAR);
     }
@@ -3900,7 +3921,7 @@ float64 float64_muladd(float64 a, float64 b, float64 c, int flags STATUS_PARAM)
 float64 float64_sqrt( float64 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp, zExp;
+    int_fast16_t aExp, zExp;
     uint64_t aSig, zSig, doubleZSig;
     uint64_t rem0, rem1, term0, term1;
     a = float64_squash_input_denormal(a STATUS_VAR);
@@ -3951,7 +3972,7 @@ float64 float64_sqrt( float64 a STATUS_PARAM )
 float64 float64_log2( float64 a STATUS_PARAM )
 {
     flag aSign, zSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t aSig, aSig0, aSig1, zSig, i;
     a = float64_squash_input_denormal(a STATUS_VAR);
 
@@ -4428,7 +4449,7 @@ float64 floatx80_to_float64( floatx80 a STATUS_PARAM )
 float128 floatx80_to_float128( floatx80 a STATUS_PARAM )
 {
     flag aSign;
-    int16 aExp;
+    int_fast16_t aExp;
     uint64_t aSig, zSig0, zSig1;
 
     aSig = extractFloatx80Frac( a );
@@ -6443,10 +6464,10 @@ uint32 float32_to_uint32_round_to_zero( float32 a STATUS_PARAM )
     return res;
 }
 
-uint16 float32_to_uint16_round_to_zero( float32 a STATUS_PARAM )
+uint_fast16_t float32_to_uint16_round_to_zero(float32 a STATUS_PARAM)
 {
     int64_t v;
-    uint16 res;
+    uint_fast16_t res;
 
     v = float32_to_int64_round_to_zero(a STATUS_VAR);
     if (v < 0) {
@@ -6497,10 +6518,10 @@ uint32 float64_to_uint32_round_to_zero( float64 a STATUS_PARAM )
     return res;
 }
 
-uint16 float64_to_uint16_round_to_zero( float64 a STATUS_PARAM )
+uint_fast16_t float64_to_uint16_round_to_zero(float64 a STATUS_PARAM)
 {
     int64_t v;
-    uint16 res;
+    uint_fast16_t res;
 
     v = float64_to_int64_round_to_zero(a STATUS_VAR);
     if (v < 0) {


### PR DESCRIPTION
Hi, I recreate the fresh pull request with three commits according to our last discussion:
1. A documentation patch about how to build S2E on a Mac.
2. A cocoa.m patch (duplicate definitions of "uint16") pulled from upstream QEMU. Because QEMU changed some .h files' location, I have to modify one single line of code pulled from upstream QEMU to make it compatible with your QEMU version.
3. A s2e_bdrv_fail patch. Maybe not the perfect patch, but it works. I explained the reason in the comment of my last commit.

I tested these patches on a Ubuntu system and it seems fine.
