### PR TITLE
JMP and NOP guards

### DIFF
--- a/guest/include/s2e-x86.h
+++ b/guest/include/s2e-x86.h
@@ -36,23 +36,23 @@
 #ifdef S2E_INSTRUCTION_USE_NOP
 # define S2E_INSTRUCTION_COMPLEX(val1, val2)            \
     ".byte 0x0F, 0x1F, 0x84, 0x42, "                    \
-          "0x00, " #val1 ", " #val2 ", 0x00\n"
+          "0x00, 0x" #val1 ", 0x" #val2 ", 0x00\n"
 #else
 # ifdef S2E_INSTRUCTION_USE_JUMP
 #  define S2E_INSTRUCTION_COMPLEX(val1, val2)           \
     "jmp .+0x08\n"                                      \
     ".byte 0x0F, 0x3F\n"                                \
-    ".byte 0x00, " #val1 ", " #val2 ", 0x00\n"
+    ".byte 0x00, 0x" #val1 ", 0x" #val2 ", 0x00\n"
 # else
 #  define S2E_INSTRUCTION_COMPLEX(val1, val2)           \
     ".byte 0x0F, 0x3F\n"                                \
-    ".byte 0x00, " #val1 ", " #val2 ", 0x00\n"          \
+    ".byte 0x00, 0x" #val1 ", 0x" #val2 ", 0x00\n"      \
     ".byte 0x00, 0x00, 0x00, 0x00\n"
 # endif
 #endif
 
 #define S2E_INSTRUCTION_SIMPLE(val)                     \
-    S2E_INSTRUCTION_COMPLEX(val, 0x00)
+    S2E_INSTRUCTION_COMPLEX(val, 00)
 
 
 
@@ -62,7 +62,7 @@ static inline int s2e_version(void)
 {
     int version;
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x00)
+        S2E_INSTRUCTION_SIMPLE(00)
         : "=a" (version)  : "a" (0)
     );
     return version;
@@ -72,7 +72,7 @@ static inline int s2e_version(void)
 static inline void s2e_enable_symbolic(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x01)
+        S2E_INSTRUCTION_SIMPLE(01)
     );
 }
 
@@ -80,7 +80,7 @@ static inline void s2e_enable_symbolic(void)
 static inline void s2e_disable_symbolic(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x02)
+        S2E_INSTRUCTION_SIMPLE(02)
     );
 }
 
@@ -89,7 +89,7 @@ static inline void s2e_message(const char *message)
 {
     __s2e_touch_string(message);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x10)
+        S2E_INSTRUCTION_SIMPLE(10)
         : : "a" (message)
     );
 }
@@ -99,7 +99,7 @@ static inline void s2e_warning(const char *message)
 {
     __s2e_touch_string(message);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0x10, 0x01)
+        S2E_INSTRUCTION_COMPLEX(10, 01)
         : : "a" (message)
     );
 }
@@ -109,7 +109,7 @@ static inline void s2e_print_expression(const char *name, int expression)
 {
     __s2e_touch_string(name);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0x07, 0x01)
+        S2E_INSTRUCTION_COMPLEX(07, 01)
         : : "a" (expression), "c" (name)
     );
 }
@@ -118,7 +118,7 @@ static inline void s2e_print_expression(const char *name, int expression)
 static inline void s2e_enable_forking(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x09)
+        S2E_INSTRUCTION_SIMPLE(09)
     );
 }
 
@@ -126,7 +126,7 @@ static inline void s2e_enable_forking(void)
 static inline void s2e_disable_forking(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x0A)
+        S2E_INSTRUCTION_SIMPLE(0A)
     );
 }
 
@@ -134,7 +134,7 @@ static inline void s2e_disable_forking(void)
 static inline void s2e_yield(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x0F)
+        S2E_INSTRUCTION_SIMPLE(0F)
     );
 }
 
@@ -143,7 +143,7 @@ static inline unsigned s2e_get_path_id(void)
 {
     unsigned id;
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x05)
+        S2E_INSTRUCTION_SIMPLE(05)
         : "=a" (id)
     );
     return id;
@@ -162,7 +162,7 @@ static inline void s2e_make_symbolic(void *buf, int size, const char *name)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x03)
+        S2E_INSTRUCTION_SIMPLE(03)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -185,7 +185,7 @@ static inline void s2e_make_concolic(void *buf, int size, const char *name)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x11)
+        S2E_INSTRUCTION_SIMPLE(11)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -200,7 +200,7 @@ static inline void s2e_make_concolic(void *buf, int size, const char *name)
 static inline void s2e_assume(int expression)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x0C)
+        S2E_INSTRUCTION_SIMPLE(0C)
         : : "a" (expression)
     );
 }
@@ -212,7 +212,7 @@ static inline int s2e_is_symbolic(void *ptr, size_t size)
     int result;
     __s2e_touch_buffer(ptr, 1);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x04)
+        S2E_INSTRUCTION_SIMPLE(04)
         : "=a" (result) : "a" (size), "c" (ptr)
     );
     return result;
@@ -230,7 +230,7 @@ static inline void s2e_concretize(void *buf, int size)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x20)
+        S2E_INSTRUCTION_SIMPLE(20)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -252,7 +252,7 @@ static inline void s2e_get_example(void *buf, int size)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x21)
+        S2E_INSTRUCTION_SIMPLE(21)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -275,7 +275,7 @@ static inline unsigned s2e_get_example_uint(unsigned val)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x21)
+        S2E_INSTRUCTION_SIMPLE(21)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -298,7 +298,7 @@ static inline void s2e_kill_state(int status, const char *message)
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0x06)
+        S2E_INSTRUCTION_SIMPLE(06)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -312,7 +312,7 @@ static inline void s2e_kill_state(int status, const char *message)
 static inline void s2e_disable_timer_interrupt(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0x50, 0x01)
+        S2E_INSTRUCTION_COMPLEX(50, 01)
     );
 }
 
@@ -320,7 +320,7 @@ static inline void s2e_disable_timer_interrupt(void)
 static inline void s2e_enable_timer_interrupt(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x50)
+        S2E_INSTRUCTION_SIMPLE(50)
     );
 }
 
@@ -328,7 +328,7 @@ static inline void s2e_enable_timer_interrupt(void)
 static inline void s2e_disable_all_apic_interrupts(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0x51, 0x01)
+        S2E_INSTRUCTION_COMPLEX(51, 01)
     );
 }
 
@@ -336,7 +336,7 @@ static inline void s2e_disable_all_apic_interrupts(void)
 static inline void s2e_enable_all_apic_interrupts(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x51)
+        S2E_INSTRUCTION_SIMPLE(51)
     );
 }
 
@@ -345,7 +345,7 @@ static inline int s2e_get_ram_object_bits(void)
 {
     int bits;
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x52)
+        S2E_INSTRUCTION_SIMPLE(52)
         : "=a" (bits)  : "a" (0)
     );
     return bits;
@@ -358,7 +358,7 @@ static inline int s2e_get_ram_object_bits(void)
 static inline void s2e_merge_point(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x70)
+        S2E_INSTRUCTION_SIMPLE(70)
     );
 }
 
@@ -370,7 +370,7 @@ static inline int s2e_open(const char *fname)
     int fd;
     __s2e_touch_string(fname);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0xEE)
+        S2E_INSTRUCTION_SIMPLE(EE)
         : "=a" (fd) : "a"(-1), "b" (fname), "c" (0)
     );
     return fd;
@@ -383,7 +383,7 @@ static inline int s2e_close(int fd)
 {
     int res;
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0xEE, 0x01)
+        S2E_INSTRUCTION_COMPLEX(EE, 01)
         : "=a" (res) : "a" (-1), "b" (fd)
     );
     return res;
@@ -404,7 +404,7 @@ static inline int s2e_read(int fd, char *buf, int count)
         "pushl %%ebx\n"
         "movl %%esi, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_COMPLEX(0xEE, 0x02)
+        S2E_INSTRUCTION_COMPLEX(EE, 02)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -419,7 +419,7 @@ static inline int s2e_read(int fd, char *buf, int count)
 static inline void s2e_memtracer_enable(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0xAC)
+        S2E_INSTRUCTION_SIMPLE(AC)
     );
 }
 
@@ -427,7 +427,7 @@ static inline void s2e_memtracer_enable(void)
 static inline void s2e_memtracer_disable(void)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0xAC, 0x01)
+        S2E_INSTRUCTION_COMPLEX(AC, 01)
     );
 }
 
@@ -445,7 +445,7 @@ static inline void s2e_rawmon_loadmodule(const char *name, unsigned loadbase, un
         "pushl %%ebx\n"
         "movl %%edx, %%ebx\n"
 #endif
-        S2E_INSTRUCTION_SIMPLE(0xAA)
+        S2E_INSTRUCTION_SIMPLE(AA)
 #ifdef __x86_64__
         "pop %%rbx\n"
 #else
@@ -476,7 +476,7 @@ static inline void s2e_rawmon_loadmodule2(const char *name,
     __s2e_touch_string(name);
 
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0xAA, 0x02)
+        S2E_INSTRUCTION_COMPLEX(AA, 02)
         : : "c" (&cfg)
     );
 }
@@ -486,7 +486,7 @@ static inline void s2e_rawmon_loadmodule2(const char *name,
 static inline void s2e_codeselector_enable_address_space(unsigned user_mode_only)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0xAE)
+        S2E_INSTRUCTION_SIMPLE(AE)
         : : "c" (user_mode_only)
     );
 }
@@ -496,7 +496,7 @@ static inline void s2e_codeselector_enable_address_space(unsigned user_mode_only
 static inline void s2e_codeselector_disable_address_space(uint64_t pagedir)
 {
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0xAE, 0x01)
+        S2E_INSTRUCTION_COMPLEX(AE, 01)
         : : "c" (pagedir)
     );
 }
@@ -505,7 +505,7 @@ static inline void s2e_codeselector_select_module(const char *moduleId)
 {
     __s2e_touch_string(moduleId);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_COMPLEX(0xAE, 0x02)
+        S2E_INSTRUCTION_COMPLEX(AE, 02)
         : : "c" (moduleId)
     );
 }
@@ -516,7 +516,7 @@ static inline void s2e_moduleexec_add_module(const char *moduleId, const char *m
     __s2e_touch_string(moduleId);
     __s2e_touch_string(moduleName);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0xAF)
+        S2E_INSTRUCTION_SIMPLE(AF)
             : : "c" (moduleId), "a" (moduleName), "d" (kernelMode)
     );
 }
@@ -531,7 +531,7 @@ static inline int s2e_invoke_plugin(const char *pluginName, void *data, uint32_t
     __s2e_touch_string(pluginName);
     __s2e_touch_buffer(data, dataSize);
     __asm__ __volatile__(
-        S2E_INSTRUCTION_SIMPLE(0x0B)
+        S2E_INSTRUCTION_SIMPLE(0B)
         : "=a" (result) : "a" (pluginName), "c" (data), "d" (dataSize) : "memory"
     );
 

--- a/guest/include/s2e.h
+++ b/guest/include/s2e.h
@@ -63,7 +63,7 @@ typedef struct _s2e_opcode_module_config_t {
 #endif
 
 #define S2E_INSTRUCTION_REGISTERS_SIMPLE(val)           \
-    S2E_INSTRUCTION_REGISTERS_COMPLEX(val, 00)
+    S2E_INSTRUCTION_REGISTERS_COMPLEX(val, 0x00)
 
 /** Forces the read of every byte of the specified string.
   * This makes sure the memory pages occupied by the string are paged in

--- a/guest/include/s2e.h
+++ b/guest/include/s2e.h
@@ -63,7 +63,7 @@ typedef struct _s2e_opcode_module_config_t {
 #endif
 
 #define S2E_INSTRUCTION_REGISTERS_SIMPLE(val)           \
-    S2E_INSTRUCTION_REGISTERS_COMPLEX(val, 0x00)
+    S2E_INSTRUCTION_REGISTERS_COMPLEX(val, 00)
 
 /** Forces the read of every byte of the specified string.
   * This makes sure the memory pages occupied by the string are paged in

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -6485,12 +6485,14 @@ static target_ulong disas_insn(DisasContext *s, target_ulong pc_start)
             SET_TB_TYPE(TB_JMP);
             tval = (int8_t)insn_get(s, OT_BYTE);
 #ifdef CONFIG_S2E
+            /* TODO magic numbers */
             if (tval == 0x06) {
                 uint16_t efof = lduw_code(s->pc);
                 if (efof == 0x3f0f) {
-                    uint64_t arg = ldl_code(s->pc+sizeof(efof));
-                    printf("\033[1mS2E custom instruction (%08lX)\033[0m\n",arg);
-                    s2e_tcg_emit_custom_instruction(g_s2e, arg);
+                    uint32_t s2e_op = ldl_code(s->pc+sizeof(efof));
+                    printf("\033[1mS2E custom instruction (%08X)\033[0m\n",
+                           s2e_op);
+                    s2e_tcg_emit_custom_instruction(g_s2e, s2e_op);
                 }
             }
 #endif

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -2269,11 +2269,8 @@ static void gen_nop_modrm(DisasContext *s, int modrm)
         case 2:
             {
 #ifdef CONFIG_S2E
-                /* TODO magic numbers */
                 if (code == 0x42) {
                     uint32_t s2e_op = ldl_code(s->pc);
-                    printf("\033[1mS2E custom instruction (%08X)\033[0m\n",
-                           s2e_op);
                     s2e_tcg_emit_custom_instruction(g_s2e, s2e_op);
                 }
 #endif
@@ -6485,13 +6482,10 @@ static target_ulong disas_insn(DisasContext *s, target_ulong pc_start)
             SET_TB_TYPE(TB_JMP);
             tval = (int8_t)insn_get(s, OT_BYTE);
 #ifdef CONFIG_S2E
-            /* TODO magic numbers */
             if (tval == 0x06) {
                 uint16_t efof = lduw_code(s->pc);
                 if (efof == 0x3f0f) {
                     uint32_t s2e_op = ldl_code(s->pc+sizeof(efof));
-                    printf("\033[1mS2E custom instruction (%08X)\033[0m\n",
-                           s2e_op);
                     s2e_tcg_emit_custom_instruction(g_s2e, s2e_op);
                 }
             }

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -2267,8 +2267,19 @@ static void gen_nop_modrm(DisasContext *s, int modrm)
             break;
         default:
         case 2:
-            s->pc += 4;
-            break;
+            {
+#ifdef CONFIG_S2E
+                /* TODO magic numbers */
+                if (code == 0x42) {
+                    uint32_t s2e_op = ldl_code(s->pc);
+                    printf("\033[1mS2E custom instruction (%08X)\033[0m\n",
+                           s2e_op);
+                    s2e_tcg_emit_custom_instruction(g_s2e, s2e_op);
+                }
+#endif
+                s->pc += 4;
+                break;
+            }
         }
     } else {
         switch (mod) {


### PR DESCRIPTION
These commits will introduce two additional ways of emitting S²E-specific instructions in the translator:
- Using a `jmp`, that jumps over the 6 bytes that define the instruction, thus hiding them from any CPU or monitoring programme that may not know the OP codes; and
- Using the 5 last bytes of the 8-byte NOP instruction (`nopl`) to mark and encode the special instructions.
